### PR TITLE
Explicit reads and writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ This library adds a number of annotations for automatically creating JSON format
 
 By using `@json` or `@jsonFlat` annotations on a case class a JSON formatter will automatically be created in the companion object.
 
+By using `@jsonReads` or `@jsonWrites` annotations on a case class a JSON reads or JSON writes (respectively) will automatically be created in the companion object, in the same style as if `@json` was used.
+
 This code:
 ```scala
 @json case class Person(name: String, age: Int)

--- a/src/main/scala/tech/minna/playjson/macros/ExtendCompanionObject.scala
+++ b/src/main/scala/tech/minna/playjson/macros/ExtendCompanionObject.scala
@@ -3,13 +3,14 @@ package tech.minna.playjson.macros
 import scala.reflect.macros.blackbox
 
 object ExtendCompanionObject {
-  def impl(c: blackbox.Context)(annottees: Seq[c.Expr[Any]])(formatter: (c.universe.TypeName, List[c.universe.ValDef]) => c.universe.Tree): c.Expr[Any] = {
+  def impl(c: blackbox.Context)(annottees: Seq[c.Expr[Any]])(formatterName: String)(formatter: (c.universe.TypeName, List[c.universe.ValDef]) => c.universe.Tree): c.Expr[Any] = {
     import c.universe._
 
     def modifiedDeclaration(classDecl: ClassDef, compDeclOpt: Option[ModuleDef] = None) = {
       val (className, fields) = extractClassNameAndFields(classDecl)
       val formatTree = formatter(className, fields)
-      val formatField = q"""implicit val jsonFormat = $formatTree"""
+      val formatterNameTerm = TermName(formatterName)
+      val formatField = q"""implicit val $formatterNameTerm = $formatTree"""
       val compDecl = addFormatterToCompanionObject(compDeclOpt, formatField, className)
 
       c.Expr {

--- a/src/main/scala/tech/minna/playjson/macros/JsonMacros.scala
+++ b/src/main/scala/tech/minna/playjson/macros/JsonMacros.scala
@@ -86,7 +86,7 @@ object JsonFormatMacro {
       case q"new json($defaultValues)" => c.eval[Boolean](c.Expr(defaultValues))
       case q"new json()" => true
     }
-    ExtendCompanionObject.impl(c)(annottees) { (className, fields) =>
+    ExtendCompanionObject.impl(c)(annottees)("jsonFormat") { (className, fields) =>
       fields.length match {
         case 0 =>
           c.abort(c.enclosingPosition, s"Cannot create JSON formatter for case class with no fields")
@@ -108,7 +108,7 @@ object JsonFormatMacro {
 
 object JsonFlatFormatMacro {
   def impl(c: blackbox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
-    ExtendCompanionObject.impl(c)(annottees) { (className, fields) =>
+    ExtendCompanionObject.impl(c)(annottees)("jsonFormat") { (className, fields) =>
       fields match {
         case List(field) =>
           jsonFormat(c)(className, field.tpt, field.name)
@@ -169,7 +169,7 @@ object JsonFlatFormatMacro {
 
 object JsonWritesFormatMacro {
   def impl(c: blackbox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
-    ExtendCompanionObject.impl(c)(annottees) { (className, fields) =>
+    ExtendCompanionObject.impl(c)(annottees)("jsonWrites") { (className, fields) =>
       fields.length match {
         case 0 =>
           c.abort(c.enclosingPosition, s"Cannot create JSON writes for case class with no fields")
@@ -193,7 +193,7 @@ object JsonReadsFormatMacro {
       case q"new jsonReads($defaultValues)" => c.eval[Boolean](c.Expr(defaultValues))
       case q"new jsonReads()" => true
     }
-    ExtendCompanionObject.impl(c)(annottees) { (className, fields) =>
+    ExtendCompanionObject.impl(c)(annottees)("jsonReads") { (className, fields) =>
       fields.length match {
         case 0 =>
           c.abort(c.enclosingPosition, s"Cannot create JSON reads for case class with no fields")

--- a/src/main/scala/tech/minna/playjson/macros/JsonMacros.scala
+++ b/src/main/scala/tech/minna/playjson/macros/JsonMacros.scala
@@ -169,7 +169,6 @@ object JsonFlatFormatMacro {
 
 object JsonWritesFormatMacro {
   def impl(c: blackbox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
-    import c.universe._
     ExtendCompanionObject.impl(c)(annottees) { (className, fields) =>
       fields.length match {
         case 0 =>
@@ -199,12 +198,12 @@ object JsonReadsFormatMacro {
         case 0 =>
           c.abort(c.enclosingPosition, s"Cannot create JSON reads for case class with no fields")
         case _ =>
-          jsonWrites(c)(defaultValues, className, fields)
+          jsonReads(c)(defaultValues, className, fields)
       }
     }
   }
 
-  def jsonWrites(c: blackbox.Context)(defaultValues: Boolean, className: c.universe.TypeName, fields: List[c.universe.ValDef]): c.universe.Tree = {
+  def jsonReads(c: blackbox.Context)(defaultValues: Boolean, className: c.universe.TypeName, fields: List[c.universe.ValDef]): c.universe.Tree = {
     import c.universe._
     if (defaultValues) {
       q"""play.api.libs.json.Json.using[play.api.libs.json.Json.WithDefaultValues].reads[$className]"""

--- a/src/test/scala/tech/minna/playjson/macros/JsonMacrosSpec.scala
+++ b/src/test/scala/tech/minna/playjson/macros/JsonMacrosSpec.scala
@@ -15,7 +15,7 @@ import play.api.libs.json.{JsString, JsSuccess, Json}
 @json protected final case class ModifiersClass(name: String)
 
 class JsonMacrosSpec extends FlatSpec with Matchers {
-  "@json" should "create a JSON formatter for a case class that have default values, and include them if given" in {
+  "@json" should "create a JSON formatter for a case class with default values, and include them if given" in {
     val product = ProductDefaults("Milk", 9.9)
     val expectedJson = Json.obj(
       "name" -> "Milk",
@@ -25,7 +25,7 @@ class JsonMacrosSpec extends FlatSpec with Matchers {
     expectedJson.asOpt[ProductDefaults] shouldEqual Some(product)
   }
 
-  it should "create a JSON formatter for a case class that have default values, and include the defaults if not given" in {
+  it should "create a JSON formatter for a case class with default values, and include the defaults if not given" in {
     val product = ProductDefaults("Milk")
     val expectedJson = Json.obj(
       "name" -> "Milk",

--- a/src/test/scala/tech/minna/playjson/macros/JsonMacrosSpec.scala
+++ b/src/test/scala/tech/minna/playjson/macros/JsonMacrosSpec.scala
@@ -9,7 +9,9 @@ import play.api.libs.json.{JsString, JsSuccess, Json}
 
 @jsonWrites case class ProductWrites(name: String, price: Double)
 
-@jsonReads case class ProductReads(name: String, price: Double)
+@jsonReads case class ProductReadsDefaults(name: String, price: Double = 12)
+
+@jsonReads(defaultValues = false) case class ProductReads(name: String, price: Double)
 
 // This case class with modifiers should compile
 @json protected final case class ModifiersClass(name: String)
@@ -109,4 +111,15 @@ class JsonMacrosSpec extends FlatSpec with Matchers {
     "Json.toJson(product)" shouldNot compile
     expectedJson.asOpt[ProductReads] shouldEqual Some(product)
   }
+
+  "@jsonReads(defaultValues=false)" should "create a JSON reads for a case class, but not a JSON writes" in {
+    val product = ProductReadsDefaults("Milk")
+    val expectedJson = Json.obj(
+      "name" -> "Milk",
+      "price" -> 12
+    )
+    "Json.toJson(product)" shouldNot compile
+    expectedJson.asOpt[ProductReadsDefaults] shouldEqual Some(product)
+  }
+
 }

--- a/src/test/scala/tech/minna/playjson/macros/JsonMacrosSpec.scala
+++ b/src/test/scala/tech/minna/playjson/macros/JsonMacrosSpec.scala
@@ -15,7 +15,7 @@ import play.api.libs.json.{JsString, JsSuccess, Json}
 @json protected final case class ModifiersClass(name: String)
 
 class JsonMacrosSpec extends FlatSpec with Matchers {
-  "@json" should "create a JSON formatter for a case class that have default values" in {
+  "@json" should "create a JSON formatter for a case class that have default values, and include them if given" in {
     val product = ProductDefaults("Milk", 9.9)
     val expectedJson = Json.obj(
       "name" -> "Milk",
@@ -23,8 +23,16 @@ class JsonMacrosSpec extends FlatSpec with Matchers {
     )
     Json.toJson(product) shouldEqual expectedJson
     expectedJson.asOpt[ProductDefaults] shouldEqual Some(product)
+  }
 
-    Json.obj("name" -> "Milk").asOpt[ProductDefaults] shouldEqual Some(ProductDefaults("Milk", price = 10.5))
+  it should "create a JSON formatter for a case class that have default values, and include the defaults if not given" in {
+    val product = ProductDefaults("Milk")
+    val expectedJson = Json.obj(
+      "name" -> "Milk",
+      "price" -> 10.5
+    )
+    Json.toJson(product) shouldEqual expectedJson
+    expectedJson.asOpt[ProductDefaults] shouldEqual Some(product)
   }
 
   "@json(defaultValues = false)" should "create a JSON formatter for a case class without default values" in {

--- a/src/test/scala/tech/minna/playjson/macros/JsonMacrosSpec.scala
+++ b/src/test/scala/tech/minna/playjson/macros/JsonMacrosSpec.scala
@@ -7,6 +7,10 @@ import play.api.libs.json.{JsString, JsSuccess, Json}
 
 @json(defaultValues = false) case class Product(name: String, price: Double)
 
+@jsonWrites case class ProductWrites(name: String, price: Double)
+
+@jsonReads case class ProductReads(name: String, price: Double)
+
 // This case class with modifiers should compile
 @json protected final case class ModifiersClass(name: String)
 
@@ -76,5 +80,25 @@ class JsonMacrosSpec extends FlatSpec with Matchers {
     val expectedJson = JsString("Milk")
     format.writes(product) shouldEqual expectedJson
     format.reads(expectedJson) shouldEqual JsSuccess(product)
+  }
+
+  "@jsonWrites" should "create a JSON writes for a case class, but not a JSON reads" in {
+    val product = ProductWrites("Milk", 9.9)
+    val expectedJson = Json.obj(
+      "name" -> "Milk",
+      "price" -> 9.9
+    )
+    Json.toJson(product) shouldEqual expectedJson
+    "expectedJson.asOpt[ProductWrite]" shouldNot compile
+  }
+
+  "@jsonReads" should "create a JSON reads for a case class, but not a JSON writes" in {
+    val product = ProductReads("Milk", 9.9)
+    val expectedJson = Json.obj(
+      "name" -> "Milk",
+      "price" -> 9.9
+    )
+    "Json.toJson(product)" shouldNot compile
+    expectedJson.asOpt[ProductReads] shouldEqual Some(product)
   }
 }


### PR DESCRIPTION
This adds support for `@jsonReads` and `@jsonWrites`, allowing you to generate only reads and writes formatters for a case class.

This is useful in the case where you want the convenience of `@json`, but you for some reason don't want the full reads and writes implementations. In my case, this was because I wanted to read json-formatted input data but had no need to output it, and the data had subtypes that I could not auto-generate writes implementations for.